### PR TITLE
Fix lint warnings. Override Datatable component style defaults.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-default",
-  "version": "0.1.0",
+  "name": "pdxtipjar",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8142,16 +8142,6 @@
         "micromatch": "^3.1.10"
       }
     },
-    "gatsby-plugin-purgecss": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-4.0.1.tgz",
-      "integrity": "sha512-sYh7gm+9dovl+QASrInSXqB2qIMdfGW+Y7+Gum//jYjvktYlFCjGUXD8k/Wiw+CmXaJh8k5avFC23Cot96SS4w==",
-      "requires": {
-        "fs-extra": "^8.1.0",
-        "loader-utils": "^1.1.0",
-        "purgecss": "^1.3.0"
-      }
-    },
     "gatsby-plugin-react-helmet": {
       "version": "3.1.24",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.24.tgz",
@@ -13199,69 +13189,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "purgecss": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.4.2.tgz",
-      "integrity": "sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==",
-      "requires": {
-        "glob": "^7.1.3",
-        "postcss": "^7.0.14",
-        "postcss-selector-parser": "^6.0.0",
-        "yargs": "^14.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
     },
     "q": {
       "version": "1.5.1",

--- a/src/components/RandomPerson.js
+++ b/src/components/RandomPerson.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Link } from "gatsby";
 import Modal from "./Modal";
 import PaymentButton from "./PaymentButton";
 import RandomButton from "./RandomButton";

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -15,6 +15,11 @@ const HEADERS = {
 
 const VISIBLE_COLUMNS = ["work", "name", "app", "support_others", "healthcare"];
 
+const tableOverrideStyles = {
+  marginBottom: '0px',
+  paddingBottom: '0px',
+};
+
 const customStyles = {
   table: {
     style: {
@@ -123,6 +128,7 @@ const Table = ({ data }) => {
           columns={columns}
           data={filteredItems}
           customStyles={customStyles}
+          style={tableOverrideStyles}
           fixedHeader
           noHeader
           overflowY

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -129,6 +129,7 @@ const Table = ({ data }) => {
           data={filteredItems}
           customStyles={customStyles}
           style={tableOverrideStyles}
+          pagination
           fixedHeader
           noHeader
           overflowY

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,7 +1,6 @@
 import { Link } from "gatsby";
 import PropTypes from "prop-types";
 import React from "react";
-import Image from "./image";
 import logo from "../images/logo.png";
 
 const Header = ({ siteTitle }) => (

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -27,8 +27,8 @@ const Layout = ({ children }) => {
       <Header siteTitle={data.site.siteMetadata.title} />
       <main>{children}</main>
       <footer>
-        <Link to="/">Home</Link> | <Link to="about">About</Link> |{" "}
-        <Link to="donate">Donate</Link> | <Link to="signup">Sign up</Link>
+        <Link to="/">Home</Link> | <Link to="/about">About</Link> |{" "}
+        <Link to="/donate">Donate</Link> | <Link to="/signup">Sign up</Link>
       </footer>
     </div>
   );

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
-import { useStaticQuery, graphql, withPrefix } from "gatsby";
+import { withPrefix } from "gatsby";
 
 function SEO({ description, title }) {
   return (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,11 +24,11 @@ const Intro = () => (
     <p>
       The premise is simple: Tip a dollar, $5, $10, $20—or whatever you’d
       like—directly to a Service Industry worker! Tip someone at random or
-      browse the <Link to="donate">full list to find your favorite spots</Link>.
+      browse the <Link to="/donate">full list to find your favorite spots</Link>.
     </p>
     <p>
       If you’re a Service Industry worker,{" "}
-      <Link to="signup">fill out the form to receive tips</Link>
+      <Link to="/signup">fill out the form to receive tips</Link>
       directly through your Cashapp, Venmo, or PayPal.
     </p>
   </div>
@@ -86,8 +86,8 @@ const IndexPage = () => {
         text="Find a random person to tip"
       />
       <nav>
-        <Link to="donate">Browse the full list</Link>
-        <Link to="signup">Sign up to receive tips</Link>
+        <Link to="/donate">Browse the full list</Link>
+        <Link to="/signup">Sign up to receive tips</Link>
       </nav>
       <Pledge />
     </Layout>


### PR DESCRIPTION
Unfortunately the data table component had some default styles that needed to be overridden. I also removed some extraneous named imports which were causing lint warnings. Lastly, Gatsby's docs prefer `<Link>` components' `to` prop to have a preceding slash. There were console warnings to indicate this. I updated the code to reflect this.